### PR TITLE
Avoid alive nodephp images

### DIFF
--- a/node-php/node8-php7.0/Dockerfile
+++ b/node-php/node8-php7.0/Dockerfile
@@ -23,4 +23,10 @@ RUN apt-get update && \
         php7.0-pdo-mysql \
     && apt-get clean
 
+RUN mkdir -p /home/app \
+    && usermod -d /home/app -l app node \
+    && chown -R app /home/app
+
+USER app
+
 WORKDIR /var/www/html

--- a/node-php/node8-php7.0/Dockerfile
+++ b/node-php/node8-php7.0/Dockerfile
@@ -24,5 +24,3 @@ RUN apt-get update && \
     && apt-get clean
 
 WORKDIR /var/www/html
-
-CMD tail -f /dev/null

--- a/node-php/node8-php7.1/Dockerfile
+++ b/node-php/node8-php7.1/Dockerfile
@@ -23,4 +23,10 @@ RUN apt-get update && \
         php7.1-pdo-mysql \
     && apt-get clean
 
+RUN mkdir -p /home/app \
+    && usermod -d /home/app -l app node \
+    && chown -R app /home/app
+
+USER app
+
 WORKDIR /var/www/html

--- a/node-php/node8-php7.1/Dockerfile
+++ b/node-php/node8-php7.1/Dockerfile
@@ -24,5 +24,3 @@ RUN apt-get update && \
     && apt-get clean
 
 WORKDIR /var/www/html
-
-CMD tail -f /dev/null


### PR DESCRIPTION
node-php containers should be temporal because they are used to run tasks, makes no sense keeping them alive.