### PR TITLE
Avoid keep alive unison

### DIFF
--- a/node-php/node8-php7.0/Dockerfile
+++ b/node-php/node8-php7.0/Dockerfile
@@ -24,5 +24,3 @@ RUN apt-get update && \
     && apt-get clean
 
 WORKDIR /var/www/html
-
-CMD tail -f /dev/null

--- a/node-php/node8-php7.1/Dockerfile
+++ b/node-php/node8-php7.1/Dockerfile
@@ -24,5 +24,3 @@ RUN apt-get update && \
     && apt-get clean
 
 WORKDIR /var/www/html
-
-CMD tail -f /dev/null

--- a/unison/2.51.2/Dockerfile
+++ b/unison/2.51.2/Dockerfile
@@ -34,4 +34,3 @@ COPY scripts/sync.sh /usr/local/bin/sync
 COPY scripts/watch.sh /usr/local/bin/watch
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD tail -f /dev/null


### PR DESCRIPTION
Following docker standards it's not necessary to keep alive unison containers as it runs temporal tasks.