### PR TITLE
Install pcntl extension

### DIFF
--- a/php/7.1-fpm/Dockerfile
+++ b/php/7.1-fpm/Dockerfile
@@ -29,6 +29,7 @@ RUN docker-php-ext-install \
   mbstring \
   mcrypt \
   opcache \
+  pcntl \
   pdo_mysql \
   soap \
   xsl \

--- a/php/7.2-fpm/Dockerfile
+++ b/php/7.2-fpm/Dockerfile
@@ -27,6 +27,7 @@ RUN docker-php-ext-install \
   intl \
   mbstring \
   opcache \
+  pcntl \
   pdo_mysql \
   soap \
   xsl \


### PR DESCRIPTION
For `bin/magento setup:static-content:deploy` we [could ](https://devdocs.magento.com/guides/v2.3/config-guide/cli/config-cli-subcommands-static-view.html)define how many jobs to run in parallel. It really speeds up this process. But it requires `pcntl` php extension.

This PR adds this extension