### PR TITLE
Remove ssh from php 7.2 image

### DIFF
--- a/php/7.2-fpm/Dockerfile
+++ b/php/7.2-fpm/Dockerfile
@@ -39,10 +39,6 @@ RUN pecl channel-update pecl.php.net \
   && docker-php-ext-enable xdebug \
   && sed -i -e 's/^zend_extension/\;zend_extension/g' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
-RUN apt-get install -y libssh2-1-dev \
-  && pecl install ssh2-1.1.2 \
-  && docker-php-ext-enable ssh2
-
 # Clean up apt-get update
 RUN rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Php 7.0 and php 7.1 images do not contains ssh extension and Magento works fine there.
My PR just removing installing not needed extension.
For those people that need to have installed this extension - they could install it using own image.