### PR TITLE
[1/2] Add Elasticsearch 6.5 image

### DIFF
--- a/elasticsearch/6.5/Dockerfile
+++ b/elasticsearch/6.5/Dockerfile
@@ -1,0 +1,7 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.5.4
+
+RUN echo "xpack.security.enabled: false" >> /usr/share/elasticsearch/config/elasticsearch.yml
+RUN bin/elasticsearch-plugin install analysis-icu && \
+    bin/elasticsearch-plugin install analysis-phonetic
+
+EXPOSE 9200 9300

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -1,6 +1,6 @@
 # Tags
 
-* `modestcoders/elasticsearch:6.5` [(Dockerfile)](https://github.com/ModestCoders/dockerfiles/blob/master/php/7.2-fpm/Dockerfile)
+* `modestcoders/elasticsearch:6.5` [(Dockerfile)](https://github.com/ModestCoders/dockerfiles/blob/master/elasticsearch/6.5/Dockerfile)
 
 # Description
 

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -1,0 +1,7 @@
+# Tags
+
+* `modestcoders/elasticsearch:6.5` [(Dockerfile)](https://github.com/ModestCoders/dockerfiles/blob/master/php/7.2-fpm/Dockerfile)
+
+# Description
+
+ElasticSearch 6.5 with analysis-icu and analysis-phonetic plugins


### PR DESCRIPTION
Parts:
[1/2]: https://github.com/ModestCoders/dockerfiles/pull/11
[2/2]: https://github.com/ModestCoders/magento2-dockergento/pull/56

Add ElasticSearch 6.5 image. Dockerfile was just copied from https://github.com/magento/magento-cloud-docker/ repo:

https://github.com/magento/magento-cloud-docker/blob/14a8859816b2fdb68df290e11ced8a66b00957cb/images/elasticsearch/6.5/Dockerfile

Related issue: https://github.com/ModestCoders/magento2-dockergento/issues/46