### PR TITLE
Php72 libsodium

### DIFF
--- a/php/7.2-fpm/Dockerfile
+++ b/php/7.2-fpm/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y \
   zip \
   procps \
   sudo \
+  wget \
   && rm -rf /var/lib/apt/lists/*
 
 RUN wget https://download.libsodium.org/libsodium/releases/LATEST.tar.gz

--- a/php/7.2-fpm/Dockerfile
+++ b/php/7.2-fpm/Dockerfile
@@ -19,6 +19,13 @@ RUN apt-get update && apt-get install -y \
   sudo \
   && rm -rf /var/lib/apt/lists/*
 
+RUN wget https://download.libsodium.org/libsodium/releases/LATEST.tar.gz
+RUN tar xvzf LATEST.tar.gz
+RUN cd libsodium-stable && \
+    ./configure && \
+    make && make check && \
+    make install
+
 RUN docker-php-ext-configure \
   gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/
 
@@ -32,7 +39,8 @@ RUN docker-php-ext-install \
   pdo_mysql \
   soap \
   xsl \
-  zip
+  zip \
+  sodium
 
 RUN docker-php-ext-enable sodium
 


### PR DESCRIPTION
Since Magento2.3.2 came out, installations were not possible anymore because of the [new libsodium dependency.](https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.2OpenSource.html#known-issues)

I added libsodium to the php72-fpm Dockerfile so that we could run it again. 

I got my inspiration [here](https://github.com/magento/magento2/issues/23405#issuecomment-520443404)