### PR TITLE
Add fatal errors logging

### DIFF
--- a/php/7.2-fpm/conf/php-fpm.conf
+++ b/php/7.2-fpm/conf/php-fpm.conf
@@ -29,3 +29,6 @@ clear_env = no
 
 ; Ensure worker stdout and stderr are sent to the main error log.
 catch_workers_output = yes
+
+; log errors
+php_admin_flag[log_errors] = on

--- a/php/7.3-fpm/conf/php-fpm.conf
+++ b/php/7.3-fpm/conf/php-fpm.conf
@@ -29,3 +29,6 @@ clear_env = no
 
 ; Ensure worker stdout and stderr are sent to the main error log.
 catch_workers_output = yes
+
+; log errors
+php_admin_flag[log_errors] = on


### PR DESCRIPTION
###
My PR improves debug of fatal errors by adding them to logs. It will be really helpful for complex cases to see when fatal error appeared when response isn't visible in the browser, for instance when request was sent from php.

### Steps to reproduce
1. put in the index.php following code:
```php
$test->testFatalError();
```
2. run following command
```bash
dockergento docker-compose logs -f --tail 0 phpfpm
```

3. go to website
4. see logs from the command

### Expected result
1. You can see fatal error in the browser, example:
```
phpfpm_1         | - -  01/Jul/2020:15:34:08 +0000 "GET /index.php" 200
phpfpm_1         | NOTICE: PHP message: PHP Fatal error:  Uncaught Error: Call to a member function testFatalError() on null in /var/www/html/pub/index.php:11
phpfpm_1         | Stack trace:
phpfpm_1         | #0 {main}
phpfpm_1         |   thrown in /var/www/html/pub/index.php on line 11

```
2. You can see fatal error in php fpm container logs (as on production servers)

### Actual result
1. ✔ You can see fatal error in the browser
2. ❌ Fatal errors not logged, example:

```
phpfpm_1         | - -  01/Jul/2020:15:34:08 +0000 "GET /index.php" 200
```