### PR TITLE
Add curl extension to node images

### DIFF
--- a/node-php/node8-php7.2/Dockerfile
+++ b/node-php/node8-php7.2/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && \
     apt-get install -y \
         php7.2 \
         php7.2-bcmath \
+        php7.2-curl \
         php7.2-gd \
         php7.2-intl \
         php7.2-mbstring \

--- a/node-php/node8-php7.3/Dockerfile
+++ b/node-php/node8-php7.3/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && \
     apt-get install -y \
         php7.3 \
         php7.3-bcmath \
+        php7.3-curl \
         php7.3-gd \
         php7.3-intl \
         php7.3-mbstring \


### PR DESCRIPTION
Hello,

Curl extensions it's needed to execute grunt tasks.
Grunt exec fails with the following message: The curl extension is required to use this Handler.

After add curl extension to node image all grunt tasks works properly.

Tested in magento commerce 2.3.3 with node images 7.2 and 7.3